### PR TITLE
Truncate the ModDependencies.txt file when rewriting it

### DIFF
--- a/HKModWizard/ModDependenciesCommand/ManageModDependenciesCommand.cs
+++ b/HKModWizard/ModDependenciesCommand/ManageModDependenciesCommand.cs
@@ -239,7 +239,7 @@ namespace HKModWizard.ModDependenciesCommand
                     }
 
                     string textContent = string.Join(Environment.NewLine, form.ModDependencies);
-                    using (FileStream fs = File.OpenWrite(depsItemPath))
+                    using (FileStream fs = File.Open(depsItemPath, FileMode.Create))
                     {
                         using (StreamWriter sw = new StreamWriter(fs))
                         {


### PR DESCRIPTION
Truncate the ModDependencies.txt file when rewriting it, by opening it in Create mode.

Without this change, removing a dependency always breaks the ModDependencies.txt file, because the trailing bytes (newsize < oldsize) are left intact.